### PR TITLE
FiBo-210: make sonar include and exclude tests correctly

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -93,5 +93,8 @@ jobs:
             -Dsonar.organization=fibo-dhbw
             -Dsonar.projectKey=Cebox82_FiBo
             -Dsonar.sources=android-app,backend
+            -Dsonar.exclusions=android-app/**/androidTest/**/*,android-app/**/test/**/*,backend/**/tests/**/*
+            -Dsonar.tests=android-app/app/src,backend
+            -Dsonar.test.inclusions=android-app/**/androidTest/**/*,android-app/**/test/**/*,backend/**/tests/**/*
             -Dsonar.java.binaries=android-app/app/build/intermediates/classes
             -Dsonar.projectName=FiBo


### PR DESCRIPTION
Please merge this asap so that it can be merged into every other PR. With this, the code smells and code duplications will be detected correctly

With this config, test coverage will still not be sent to sonarcloud