### PR TITLE
FiBo-340 reset error text

### DIFF
--- a/android-app/app/src/androidTest/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragmentTest.java
+++ b/android-app/app/src/androidTest/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragmentTest.java
@@ -317,7 +317,7 @@ public class AddingFragmentTest {
 
     @Test
     public void testExpenseErrorsDisappearOnIncomeTabClick() {
-        // click on the okay button without input, and test that every field has an error
+        // click on the okay button without input
         onView(withId(R.id.okayButton))
                 .perform(scrollTo())
                 .perform(click());
@@ -352,6 +352,47 @@ public class AddingFragmentTest {
                 .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_address_field)))));
     }
 
+    @Test
+    public void testIncomeErrorsDisappearOnExpenseTabClick() {
+        // click on income tab
+        onView(withText(R.string.adding_income))
+                .perform(scrollTo())
+                .perform(click());
+
+        // click on the okay button without input
+        onView(withId(R.id.okayButton))
+                .perform(scrollTo())
+                .perform(click());
+
+        // check that error messages of text layouts are displayed
+        onView(withId(R.id.store_text_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_source_field))));
+        onView(withId(R.id.amount_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_amount_field))));
+        onView(withId(R.id.date_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_date_field))));
+        onView(withId(R.id.category_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_category_field))));
+        onView(withId(R.id.address_text_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_address_field))));
+
+        // click on expense tab
+        onView(withText(R.string.adding_expense))
+                .perform(scrollTo())
+                .perform(click());
+
+        // check that text layouts no longer have the error message
+        onView(withId(R.id.store_text_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_source_field)))));
+        onView(withId(R.id.amount_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_amount_field)))));
+        onView(withId(R.id.date_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_date_field)))));
+        onView(withId(R.id.category_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_category_field)))));
+        onView(withId(R.id.address_text_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_address_field)))));
+    }
 
     public static ViewAction clickIcon(boolean isEndIcon) {
         return new ViewAction() {

--- a/android-app/app/src/androidTest/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragmentTest.java
+++ b/android-app/app/src/androidTest/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragmentTest.java
@@ -14,6 +14,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isNotEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.not;
 import static de.dhbw.ka.se.fibo.TestMatchers.hasTextInputLayoutErrorText;
 
 import android.content.Context;
@@ -312,6 +313,43 @@ public class AddingFragmentTest {
         // Check that you can no longer click the confirm button
         onView(withId(com.google.android.material.R.id.confirm_button))
                 .check(matches(isNotEnabled()));
+    }
+
+    @Test
+    public void testExpenseErrorsDisappearOnIncomeTabClick() {
+        // click on the okay button without input, and test that every field has an error
+        onView(withId(R.id.okayButton))
+                .perform(scrollTo())
+                .perform(click());
+
+        // check that error messages of text layouts are displayed
+        onView(withId(R.id.store_text_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_store_field))));
+        onView(withId(R.id.amount_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_amount_field))));
+        onView(withId(R.id.date_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_date_field))));
+        onView(withId(R.id.category_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_category_field))));
+        onView(withId(R.id.address_text_layout))
+                .check(matches(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_address_field))));
+
+        // click on income tab
+        onView(withText(R.string.adding_income))
+                .perform(scrollTo())
+                .perform(click());
+
+        // check that text layouts no longer have the error message
+        onView(withId(R.id.store_text_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_store_field)))));
+        onView(withId(R.id.amount_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_amount_field)))));
+        onView(withId(R.id.date_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_date_field)))));
+        onView(withId(R.id.category_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_category_field)))));
+        onView(withId(R.id.address_text_layout))
+                .check(matches(not(hasTextInputLayoutErrorText(appContext.getString(R.string.error_message_address_field)))));
     }
 
 

--- a/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
+++ b/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
@@ -139,12 +139,12 @@ public class AddingFragment extends Fragment {
                     newCashFlowType = CashflowType.INCOME;
                     binding.storeTextLayout.setHint(requireContext().getString(R.string.source));
                 }
-                resetErrorMessages();
             }
 
             @Override
             public void onTabUnselected(TabLayout.Tab tab) {
                 // Not needed as this will be handled in onTabSelected
+                resetErrorMessages();
             }
 
             @Override

--- a/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
+++ b/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
@@ -216,19 +216,6 @@ public class AddingFragment extends Fragment {
         textfields.add(addressLayout);
 
         textfields.forEach(field -> field.setErrorEnabled(false));
-
-//        Map<TextInputLayout, String> fieldsToBeChecked = new HashMap<>();
-//        if (CashflowType.EXPENSE == newCashFlowType) {
-//            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_store_field));
-//        } else {
-//            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_source_field));
-//        }
-//        fieldsToBeChecked.put(amountLayout, getString(R.string.error_message_amount_field));
-//        fieldsToBeChecked.put(dateTextLayout, getString(R.string.error_message_date_field));
-//        fieldsToBeChecked.put(categoriesDropdownLayout, getString(R.string.error_message_category_field));
-//        fieldsToBeChecked.put(addressLayout, getString(R.string.error_message_address_field));
-//
-//        fieldsToBeChecked.keySet().forEach(field -> field.setErrorEnabled(false));
     }
 
     private String getFieldValue(TextView field) {

--- a/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
+++ b/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
@@ -208,18 +208,27 @@ public class AddingFragment extends Fragment {
     }
 
     private void resetErrorMessages() {
-        Map<TextInputLayout, String> fieldsToBeChecked = new HashMap<>();
-        if (CashflowType.EXPENSE == newCashFlowType) {
-            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_store_field));
-        } else {
-            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_source_field));
-        }
-        fieldsToBeChecked.put(amountLayout, getString(R.string.error_message_amount_field));
-        fieldsToBeChecked.put(dateTextLayout, getString(R.string.error_message_date_field));
-        fieldsToBeChecked.put(categoriesDropdownLayout, getString(R.string.error_message_category_field));
-        fieldsToBeChecked.put(addressLayout, getString(R.string.error_message_address_field));
+        List<TextInputLayout> textfields = new ArrayList<>();
+        textfields.add(storeLayout);
+        textfields.add(amountLayout);
+        textfields.add(dateTextLayout);
+        textfields.add(categoriesDropdownLayout);
+        textfields.add(addressLayout);
 
-        fieldsToBeChecked.keySet().forEach(field -> field.setErrorEnabled(false));
+        textfields.forEach(field -> field.setErrorEnabled(false));
+
+//        Map<TextInputLayout, String> fieldsToBeChecked = new HashMap<>();
+//        if (CashflowType.EXPENSE == newCashFlowType) {
+//            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_store_field));
+//        } else {
+//            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_source_field));
+//        }
+//        fieldsToBeChecked.put(amountLayout, getString(R.string.error_message_amount_field));
+//        fieldsToBeChecked.put(dateTextLayout, getString(R.string.error_message_date_field));
+//        fieldsToBeChecked.put(categoriesDropdownLayout, getString(R.string.error_message_category_field));
+//        fieldsToBeChecked.put(addressLayout, getString(R.string.error_message_address_field));
+//
+//        fieldsToBeChecked.keySet().forEach(field -> field.setErrorEnabled(false));
     }
 
     private String getFieldValue(TextView field) {

--- a/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
+++ b/android-app/app/src/main/java/de/dhbw/ka/se/fibo/ui/adding/AddingFragment.java
@@ -139,6 +139,7 @@ public class AddingFragment extends Fragment {
                     newCashFlowType = CashflowType.INCOME;
                     binding.storeTextLayout.setHint(requireContext().getString(R.string.source));
                 }
+                resetErrorMessages();
             }
 
             @Override
@@ -204,6 +205,21 @@ public class AddingFragment extends Fragment {
         }
 
         return null;
+    }
+
+    private void resetErrorMessages() {
+        Map<TextInputLayout, String> fieldsToBeChecked = new HashMap<>();
+        if (CashflowType.EXPENSE == newCashFlowType) {
+            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_store_field));
+        } else {
+            fieldsToBeChecked.put(storeLayout, getString(R.string.error_message_source_field));
+        }
+        fieldsToBeChecked.put(amountLayout, getString(R.string.error_message_amount_field));
+        fieldsToBeChecked.put(dateTextLayout, getString(R.string.error_message_date_field));
+        fieldsToBeChecked.put(categoriesDropdownLayout, getString(R.string.error_message_category_field));
+        fieldsToBeChecked.put(addressLayout, getString(R.string.error_message_address_field));
+
+        fieldsToBeChecked.keySet().forEach(field -> field.setErrorEnabled(false));
     }
 
     private String getFieldValue(TextView field) {


### PR DESCRIPTION
Error messages now reset whenever the user clicks on the other tab in the adding fragment. I added tests for both cases (income->expense + expense->income)